### PR TITLE
Add inner ref to NavItem

### DIFF
--- a/components/layout/nav/NavItem.es6.js
+++ b/components/layout/nav/NavItem.es6.js
@@ -12,6 +12,7 @@ type Props = {
   disabled: boolean,
   showArrow: boolean,
   icon?: Node,
+  innerRef: { current: null | React$ElementRef<ElementType> },
   actionIcon?: Node,
   badge?: string | number,
   active: boolean,
@@ -36,28 +37,32 @@ class NavItem extends React.Component<Props> {
   }
 
   render() {
-    const { disabled, className, icon, label, showArrow, active, onClick, onActionClick, actionIcon, badge } = this.props
-    const classNames = classnames({
-      'ds-nav__item': true,
-      'ds-nav__item--disabled': disabled,
-      'ds-nav__item--active': active,
-    }, className)
-
+    const {
+      disabled,
+      className,
+      icon,
+      innerRef,
+      label,
+      showArrow,
+      active,
+      onClick,
+      onActionClick,
+      actionIcon,
+      badge
+    } = this.props
+    const classNames = classnames(
+      {
+        'ds-nav__item': true,
+        'ds-nav__item--disabled': disabled,
+        'ds-nav__item--active': active
+      },
+      className
+    )
     return (
-      <div className={classNames} onClick={onClick}>
-        {icon && (
-          <div className="ds-nav__item-icon">
-            {icon}
-          </div>
-        )}
-        <div className="ds-nav__item-label">
-          {label}
-        </div>
-        {badge && (
-          <div className="ds-nav__item-badge">
-            {badge}
-          </div>
-        )}
+      <div className={classNames} onClick={onClick} ref={innerRef}>
+        {icon && <div className="ds-nav__item-icon">{icon}</div>}
+        <div className="ds-nav__item-label">{label}</div>
+        {badge && <div className="ds-nav__item-badge">{badge}</div>}
         {actionIcon && onActionClick && (
           <div className="ds-nav__item-action" onClick={this.handleActionClick}>
             {actionIcon}
@@ -73,4 +78,6 @@ class NavItem extends React.Component<Props> {
   }
 }
 
-export default NavItem
+export default React.forwardRef((props, ref) => (
+  <NavItem innerRef={ref} {...props} />
+))

--- a/components/layout/nav/NavItem.es6.js
+++ b/components/layout/nav/NavItem.es6.js
@@ -12,7 +12,7 @@ type Props = {
   disabled: boolean,
   showArrow: boolean,
   icon?: Node,
-  innerRef: { current: null | React$ElementRef<React$ElementType> },
+  innerRef: { current: null | HTMLDivElement } | ((null | HTMLDivElement) => mixed),
   actionIcon?: Node,
   badge?: string | number,
   active: boolean,
@@ -78,6 +78,6 @@ class NavItem extends React.Component<Props> {
   }
 }
 
-export default React.forwardRef((props, ref) => (
+export default React.forwardRef<Props, HTMLDivElement>((props, ref) => (
   <NavItem innerRef={ref} {...props} />
 ))

--- a/components/layout/nav/NavItem.es6.js
+++ b/components/layout/nav/NavItem.es6.js
@@ -12,7 +12,7 @@ type Props = {
   disabled: boolean,
   showArrow: boolean,
   icon?: Node,
-  innerRef: { current: null | React$ElementRef<ElementType> },
+  innerRef: { current: null | React$ElementRef<React$ElementType> },
   actionIcon?: Node,
   badge?: string | number,
   active: boolean,


### PR DESCRIPTION
This PR adds a ref prop to the NavItem component so that refs can be accessed to add functionality without modifying the base component.