### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b12/metronome",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "",
   "main": "index.es6.js",
   "scripts": {


### PR DESCRIPTION
Forgot to bump the package version. This PR bumps it.

https://github.com/b12io/metronome/pull/51