### PR TITLE
Hide the drag and drop icon if drag and drop is disabled

### DIFF
--- a/components/layout/list/DragList.es6.js
+++ b/components/layout/list/DragList.es6.js
@@ -49,7 +49,7 @@ class DragList extends React.Component {
               dragStyles={provided.draggableStyle}
               className={getItemClassNames(snapshot.isDragging, collectionList, cardList)}
             >
-              <ListItemIcon draggableIcon {...provided.dragHandleProps} />
+              {!isDragAndDropDisabled && <ListItemIcon draggableIcon {...provided.dragHandleProps} />}
               {content}
             </ListItem>,
             <div key={`key-${draggableId}`}>{provided.placeholder}</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b12/metronome",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "index.es6.js",
   "scripts": {


### PR DESCRIPTION
Currently if drag and drop is disabled we cannot edit the order in the list, **but** we still see the drag and drop icon on the left from the list item:
<img width="322" alt="Screen Shot 2022-10-07 at 13 03 11" src="https://user-images.githubusercontent.com/34861122/194487673-8823de71-81a9-4392-bc65-c5450f734429.png">

We could hide this icon to make it obvious why you cannot edit the list order.
<img width="322" alt="Screen Shot 2022-10-07 at 12 53 28" src="https://user-images.githubusercontent.com/34861122/194487924-af2bd64f-be1d-4904-8a49-2240ec2a2e5a.png">
