### PR TITLE
Harden npm publish workflow against toolchain drift

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -24,6 +24,32 @@ jobs:
           yarn
           make lint
 
+  # Exercises the release path on every PR, so toolchain drift surfaces here
+  # instead of during a tagged release — where a failure means re-tagging.
+  # Keep the node-version and steps in sync with publish.yml.
+  publish-dry-run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup Node 🔧
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify npm supports trusted publishing
+        run: |
+          min=$(node -p "require('./package.json').engines.npm.replace(/[^0-9.]/g, '')")
+          cur=$(npm -v)
+          echo "node $(node -v) / npm $cur (need npm >= $min)"
+          [ "$(printf '%s\n%s\n' "$min" "$cur" | sort -V | head -1)" = "$min" ] \
+            || { echo "::error::npm $cur is below the $min required for OIDC trusted publishing"; exit 1; }
+
+      - name: Pack 📦
+        run: npm publish --dry-run
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,17 @@ on:
   push:
     tags:
       - 'v*'
+  # Allows retrying a failed release without deleting and re-pushing the tag.
+  workflow_dispatch:
 
 permissions:
   id-token: write # Required for OIDC
   contents: read
+
+# Never cancel a publish that is already talking to the registry.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -16,11 +23,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 24 (LTS) bundles npm 11.16.0, which already satisfies the
+      # engines.npm >= 11.5.1 that OIDC trusted publishing needs. Nothing in
+      # the release path resolves a floating version over the network, so this
+      # job behaves the same today and a year from now. Do not "upgrade" this
+      # to Node 22: that line never shipped an npm past 10.9.x.
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
+      - name: Verify npm supports trusted publishing
+        run: |
+          min=$(node -p "require('./package.json').engines.npm.replace(/[^0-9.]/g, '')")
+          cur=$(npm -v)
+          echo "node $(node -v) / npm $cur (need npm >= $min)"
+          [ "$(printf '%s\n%s\n' "$min" "$cur" | sort -V | head -1)" = "$min" ] \
+            || { echo "::error::npm $cur is below the $min required for OIDC trusted publishing"; exit 1; }
+
       - run: npm publish


### PR DESCRIPTION
The v1.1.36 release failed without any commit having changed: the workflow pinned node 20 but installed `npm@latest`, and npm 12 now requires node ^22.22.2 || ^24.15.0 || >=26.0.0.

Rather than re-pin the floating install, remove it. Node 24 (LTS) bundles npm 11.16.0, which already satisfies the engines.npm >= 11.5.1 that OIDC trusted publishing requires, so the npm version becomes a property of the pinned node major instead of a version resolved over the network at release time. Note node 22 is not an option here: that line never shipped an npm past 10.9.x, so it would silently break trusted publishing.

Two changes make failures cheaper to handle:

- `workflow_dispatch` on publish, so a failed release can be retried without deleting and re-pushing the tag. Tag-triggered runs use the workflow file as of the tag, so re-running a failed job would otherwise keep using the broken version.
- A `publish-dry-run` job on PRs running the same toolchain plus `npm publish --dry-run`, so drift surfaces on an ordinary PR rather than mid-release.

Both publish paths assert npm satisfies engines.npm before publishing, so an inadequate npm fails loudly instead of as an opaque OIDC error.